### PR TITLE
Fix V591 warning from PVS-Studio Static Analyzer

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -31,6 +31,7 @@ static int draw_rectangle(lua_State *L)
 	glVertex2f(width, height);
 	glVertex2f(0.0f, height);
 	glEnd();
+        return (0);
 }
 
 static int key_pressed(int key)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Non-void function should return a value.