### PR TITLE
Fix V557 warning from PVS-Studio Static Analyzer

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	char buff[10000];
-	int size = fread(buff, 1, 10000, fp);
+        int size = fread(buff, 1, sizeof(buff)-1, fp);
 	buff[size] = 0;
 	fclose(fp);
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Array overrun is possible. The value of 'size' index could reach 10000.